### PR TITLE
allow fetch as request

### DIFF
--- a/driver.js
+++ b/driver.js
@@ -623,10 +623,7 @@ class Site {
 
     page.on('request', async (request) => {
       try {
-        if ([
-        'xhr',
-        'fetch'
-        ].includes(request.resourceType())
+        if (['xhr', 'fetch'].includes(request.resourceType())
         ) {
           let hostname
 
@@ -673,7 +670,7 @@ class Site {
           if (Object.keys(this.options.headers).length) {
             const headers = {
               ...request.headers(),
-              ...this.options.headers
+              ...this.options.headers,
             }
 
             request.continue({ headers })

--- a/driver.js
+++ b/driver.js
@@ -623,7 +623,11 @@ class Site {
 
     page.on('request', async (request) => {
       try {
-        if (request.resourceType() === 'xhr') {
+        if ([
+        'xhr',
+        'fetch'
+        ].includes(request.resourceType())
+        ) {
           let hostname
 
           try {
@@ -660,9 +664,7 @@ class Site {
             'fetch',
             'xhr',
             ...(this.options.noScripts ? [] : ['script'])
-          ].includes(
-            request.resourceType()
-          )
+          ].includes(request.resourceType())
         ) {
           request.abort('blockedbyclient')
         } else {

--- a/driver.js
+++ b/driver.js
@@ -655,7 +655,12 @@ class Site {
         if (
           (responseReceived && request.isNavigationRequest()) ||
           request.frame() !== page.mainFrame() ||
-          !['document', ...(this.options.noScripts ? [] : ['script']), 'fetch'].includes(
+          ![
+            'document',
+            'fetch',
+            'xhr',
+            ...(this.options.noScripts ? [] : ['script'])
+          ].includes(
             request.resourceType()
           )
         ) {
@@ -666,7 +671,7 @@ class Site {
           if (Object.keys(this.options.headers).length) {
             const headers = {
               ...request.headers(),
-              ...this.options.headers,
+              ...this.options.headers
             }
 
             request.continue({ headers })

--- a/driver.js
+++ b/driver.js
@@ -623,8 +623,7 @@ class Site {
 
     page.on('request', async (request) => {
       try {
-        if (['xhr', 'fetch'].includes(request.resourceType())
-        ) {
+        if (['xhr', 'fetch'].includes(request.resourceType())) {
           let hostname
 
           try {
@@ -656,12 +655,9 @@ class Site {
         if (
           (responseReceived && request.isNavigationRequest()) ||
           request.frame() !== page.mainFrame() ||
-          ![
-            'document',
-            'fetch',
-            'xhr',
-            ...(this.options.noScripts ? [] : ['script'])
-          ].includes(request.resourceType())
+          !['document', 'fetch', 'xhr', ...(this.options.noScripts ? [] : ['script'])].includes(
+            request.resourceType()
+          )
         ) {
           request.abort('blockedbyclient')
         } else {

--- a/driver.js
+++ b/driver.js
@@ -647,7 +647,7 @@ class Site {
         if (
           (responseReceived && request.isNavigationRequest()) ||
           request.frame() !== page.mainFrame() ||
-          !['document', ...(this.options.noScripts ? [] : ['script'])].includes(
+          !['document', ...(this.options.noScripts ? [] : ['script']), 'fetch'].includes(
             request.resourceType()
           )
         ) {


### PR DESCRIPTION
Vermoedelijk is wappa om performance-redenen beperkt in requests types. 
React websites van SIM gebruiken fetch om vanuit main.js (geladen vanaf 3rd party / cdn) om alle resources te laden, zie:

https://www.ameland.nl / https://www.achtkarspelen.nl

Door in driver.js naast 'document' en 'script' ook 'fetch' toe te staan zorg je dat de requests niet geblokkeerd worden en zo de verschillende Analytics-tools geladen worden.

driver.js regel 658:

```JS
if (
          (responseReceived && request.isNavigationRequest()) ||
          request.frame() !== page.mainFrame() ||
          !['document', ...(this.options.noScripts ? [] : ['script']), 'fetch'].includes(
            request.resourceType()
          )
        )
```

Op deze manier lukt het wel. Is een tijdelijke oplossing, want misschien moeten we de wappa efficiëntie een stukje terugschroeven om betere resultaten te realiseren.