### PR TITLE
added origKey to deduplication filter

### DIFF
--- a/driver.js
+++ b/driver.js
@@ -1424,19 +1424,22 @@ class Site {
       .concat(detections)
       .filter(
         (
-          { technology: { name }, pattern: { regex, type }, version },
+          { technology: { name }, pattern: { regex, type, origKey }, version },
           index,
           detections
         ) =>
           detections.findIndex(
             ({
               technology: { name: _name },
-              pattern: { regex: _regex, type: _type },
+              pattern: { regex: _regex, type: _type, origKey: _origKey },
               version: _version,
             }) =>
               type === _type &&
               name === _name &&
               version === _version &&
+              (origKey !== undefined || _origKey !== undefined
+                ? origKey === _origKey
+                : true) &&
               (!regex || regex.toString() === _regex.toString())
           ) === index
       )

--- a/driver.js
+++ b/driver.js
@@ -1437,9 +1437,7 @@ class Site {
               type === _type &&
               name === _name &&
               version === _version &&
-              (origKey !== undefined || _origKey !== undefined
-                ? origKey === _origKey
-                : true) &&
+              origKey === _origKey &&
               (!regex || regex.toString() === _regex.toString())
           ) === index
       )


### PR DESCRIPTION
Considers `pattern.origKey` when de-duplicating detections to avoid collapsing distinct patterns.

**Detection deduplication (`driver.js`)**:

Extend uniqueness check in `onDetect` to include `pattern.origKey` (when defined) alongside `type`, `name`, `version`, and `regex`.